### PR TITLE
Fix hard-mode sound playing in snake

### DIFF
--- a/snake/snake.js
+++ b/snake/snake.js
@@ -232,6 +232,23 @@ function crash() {
   setTimeout(disolveSnake, 100);
 }
 
+// Play sound when snake is eating an apple.
+// Note: when two apples are eating quickly,
+// one after the other, we ensure that we
+// play both sounds. To do so, we pause
+// the first sound (currently playing),
+// reset the player and play the second one.
+// With this, the player will hear to apple
+// eating sounds.
+function playEatSound() {
+  const apple = document.getElementById('apple');
+  if(!apple.paused) {
+    apple.pause();
+    apple.currentTime = 0;
+  }
+  apple.play();
+}
+
 // Animate the destruction of the current snake.
 function disolveSnake() {
   var snake = snakes[snakeIndex];
@@ -379,7 +396,7 @@ Snake.prototype.step = function(initialGrow) {
     crash();
     return;
   } else if (result == moveResult.FOOD) {
-    document.getElementById('apple').play();
+    playEatSound();
     addFood();
   } else if (result == moveResult.FREE && !initialGrow) {
     this.shrink();


### PR DESCRIPTION
Before the commit/content: Thanks for this great and fun little project 😄 ! 

There is a bug in the coding: When playing snake in hard mode,
and two apples where right next to each other, the player can only
hear one sound. The player should hear both apple-eating sounds.

Again, this bug only appeared in hard-mode. To reproduce, I have
manually put two apples next to each other in the field
(position x, y and x+1, y) and steered snake horizontally over the two
apples.

This fix implemented as part of this commit is to pause the first sound
if playing, reset the audio and play again. With this, the player at
least hears the beginning of one sound and the full second sound.

@NeilFraser  please let me know if there's anything else to test or you'd prefer another implementation to fix this bug 😄 . Great games by the way!